### PR TITLE
Fix clipboard CPU spam

### DIFF
--- a/util/clipboard.py
+++ b/util/clipboard.py
@@ -3,6 +3,7 @@
 from threading import Thread
 
 import pyperclip
+import time
 
 
 class ClipboardListener(Thread):
@@ -16,6 +17,7 @@ class ClipboardListener(Thread):
 
     def run(self):
         while True:
+            time.sleep(0.2)
             # pyperclip.paste() spamming may interfere with other clipboard listeners
             if not self.listening:
                 continue


### PR DESCRIPTION
Only check clipboard once every 200ms instead of using 20% cpu 